### PR TITLE
Add unified CPI mart model with Eurostat, SSB, and FRED sources

### DIFF
--- a/models/marts/cpi.sql
+++ b/models/marts/cpi.sql
@@ -1,0 +1,174 @@
+{{ config(materialized='table') }}
+
+WITH base AS (
+    -- Eurostat HICP: monthly index values by country
+    SELECT
+        tp.period_type,
+        tp.period_code,
+        e.geo AS country,
+        e.indicator,
+        e.description,
+        e.value,
+        tp.start_date,
+        tp.end_date
+    FROM {{ source('stage', 'eurostat_series_observations') }} AS e
+    INNER JOIN {{ source('public', 'time_periods') }} AS tp
+        ON TO_CHAR(e.date, 'YYYY"M"MM') = tp.period_code
+
+    UNION ALL
+
+    -- Norway CPI (SSB 14700): total consumption group, index measure
+    SELECT
+        tp.period_type,
+        tp.period_code,
+        'NO' AS country,
+        'CPI' AS indicator,
+        'Consumer Price Index (2025=100)' AS description,
+        s.value,
+        tp.start_date,
+        tp.end_date
+    FROM {{ ref('ssb_14700_cpi_by_group') }} AS s
+    INNER JOIN {{ source('public', 'time_periods') }} AS tp
+        ON s.period_id = tp.period_id
+    WHERE s.consumption_group = '00' AND s.measure_type = 'index'
+
+    UNION ALL
+
+    -- Norway adjusted CPI (SSB 14706): index measure only
+    SELECT
+        tp.period_type,
+        tp.period_code,
+        'NO' AS country,
+        CASE s.consumption_group
+            WHEN 'KPI-JA' THEN 'CPI-AT'
+            WHEN 'KPI-JAE' THEN 'CPI-ATE'
+            WHEN 'KPI-JE' THEN 'CPI-AE'
+            WHEN 'KPI-JEL' THEN 'CPI-AEL'
+            ELSE s.consumption_group
+        END AS indicator,
+        CASE s.consumption_group
+            WHEN 'KPI-JA'
+                THEN 'CPI adjusted for tax changes.'
+            WHEN 'KPI-JAE'
+                THEN 'CPI adjusted for tax changes and excluding energy products'
+            WHEN 'KPI-JE'
+                THEN 'CPI excluding energy products'
+            WHEN 'KPI-JEL'
+                THEN 'CPI excluding electricity'
+            ELSE s.consumption_group
+        END AS description,
+        s.value,
+        tp.start_date,
+        tp.end_date
+    FROM {{ ref('ssb_14706_adjusted_cpi_by_group') }} AS s
+    INNER JOIN {{ source('public', 'time_periods') }} AS tp
+        ON s.period_id = tp.period_id
+    WHERE s.measure_type = 'index'
+
+    UNION ALL
+
+    -- US CPI (FRED CPIAUCSL): daily -> monthly average
+    SELECT
+        tp.period_type,
+        tp.period_code,
+        'US' AS country,
+        'CPI' AS indicator,
+        'Consumer Price Index for All Urban Consumers: All Items' AS description,
+        AVG(f.value) AS value,
+        tp.start_date,
+        tp.end_date
+    FROM {{ source('stage', 'fred_series_observations') }} AS f
+    INNER JOIN {{ source('public', 'time_periods') }} AS tp
+        ON TO_CHAR(f.date, 'YYYY"M"MM') = tp.period_code
+    WHERE f.indicator = 'CPIAUCSL' AND f.value IS NOT NULL
+    GROUP BY
+        tp.period_type,
+        tp.period_code,
+        tp.start_date,
+        tp.end_date
+),
+
+with_changes AS (
+    SELECT
+        *,
+        ROUND(
+            (
+                (value - LAG(value, 12) OVER w)
+                / NULLIF(LAG(value, 12) OVER w, 0)
+            ) * 100,
+            2
+        ) AS yearly_change,
+        ROUND(
+            (
+                (value - LAG(value, 1) OVER w)
+                / NULLIF(LAG(value, 1) OVER w, 0)
+            ) * 100,
+            2
+        ) AS monthly_change
+    FROM base
+    WINDOW w AS (
+        PARTITION BY country, indicator
+        ORDER BY start_date
+    )
+),
+
+unpivoted AS (
+    SELECT
+        period_type,
+        period_code,
+        country,
+        indicator,
+        description,
+        'index' AS measure_type,
+        value,
+        start_date,
+        end_date
+    FROM with_changes
+
+    UNION ALL
+
+    SELECT
+        period_type,
+        period_code,
+        country,
+        indicator,
+        description,
+        'yearly_change' AS measure_type,
+        yearly_change AS value,
+        start_date,
+        end_date
+    FROM with_changes
+    WHERE yearly_change IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+        period_type,
+        period_code,
+        country,
+        indicator,
+        description,
+        'monthly_change' AS measure_type,
+        monthly_change AS value,
+        start_date,
+        end_date
+    FROM with_changes
+    WHERE monthly_change IS NOT NULL
+)
+
+SELECT
+    period_type,
+    period_code,
+    country,
+    indicator,
+    description,
+    measure_type,
+    value,
+    start_date,
+    end_date
+FROM unpivoted
+ORDER BY
+    country,
+    indicator,
+    period_code,
+    measure_type

--- a/models/marts/schema.yml
+++ b/models/marts/schema.yml
@@ -1,6 +1,32 @@
 version: 2
 
 models:
+  - name: cpi
+    description: 'Unified consumer price index data from Eurostat HICP, Norway CPI (SSB), and US CPI (FRED).'
+    columns:
+      - name: country
+        tests:
+          - not_null
+      - name: indicator
+        tests:
+          - not_null
+      - name: period_code
+        tests:
+          - not_null
+      - name: measure_type
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['index', 'yearly_change', 'monthly_change']
+      - name: value
+      - name: start_date
+        tests:
+          - not_null
+      - name: end_date
+        tests:
+          - not_null
+
   - name: currencies
     columns:
       - name: year_month

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -177,6 +177,23 @@ sources:
             tests: [not_null]
           - name: value
           - name: created_at
+      - name: eurostat_series_observations
+        description: 'HICP data fetched from the Eurostat Statistics API.'
+        columns:
+          - name: date
+            description: 'First day of the observation month'
+          - name: geo
+            description: 'Eurostat geographical code (e.g. EA20, NO, UK, DE)'
+          - name: indicator
+            description: 'Indicator code (e.g. HICP_All-items)'
+          - name: description
+            description: 'Human-readable indicator description'
+          - name: unit
+            description: 'Unit of measurement (e.g. Index, 2015=100)'
+          - name: value
+            description: 'Observation value'
+          - name: created_at
+            description: 'Timestamp when the record was created'
       - name: ssb_14706_adjusted_cpi_by_group
         description: 'Raw adjusted CPI data from SSB table 14706'
         columns:


### PR DESCRIPTION
Creates a new cpi mart model combining Eurostat HICP, Norway CPI (SSB 14700/14706), and US CPI (FRED CPIAUCSL) with yearly/monthly change calculations

Adds corresponding schema tests and documentation in models/marts/schema.yml

Registers eurostat_series_observations as a source in models/sources.yml